### PR TITLE
Refactoring+Updating libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+	classpath("io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE")
     }
 }
 

--- a/src/main/java/rethinkdb/db/RethinkDBConfiguration.java
+++ b/src/main/java/rethinkdb/db/RethinkDBConfiguration.java
@@ -1,12 +1,24 @@
 package rethinkdb.db;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 public class RethinkDBConfiguration {
-    // connect to docker
-    public static final String DBHOST = "192.168.99.100";
+
+    @Autowired
+    private Environment env;
+
+    public static String DBHOST = "127.0.0.1";
+
+    @PostConstruct
+    public void init() {
+        this.DBHOST = this.env.getProperty("rethinkdb.dbhost");
+    }
 
     @Bean
     public RethinkDBConnectionFactory connectionFactory() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+rethinkdb.dbhost=127.0.0.1
+server.port=8090


### PR DESCRIPTION
Moving hardcoded DBHOST to application.properties. My `gradle bootrun` mistakenly giving db connection timeout error msg. Updating dependency-management-plugin to 0.6.1.RELEASE for issue : https://discuss.gradle.org/t/3-0-m1-springboot-1-3-5-project-fails-to-build-aborts-with-an-error-message-on-creation-of-dependencymanagementreporttask/17999